### PR TITLE
[Feat] BaseMonoBehaviour 구현

### DIFF
--- a/unity-skill-lab/Assets/Scripts/Root/Util/MonoBehaviourBase.cs
+++ b/unity-skill-lab/Assets/Scripts/Root/Util/MonoBehaviourBase.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using UnityEngine;
+
+namespace Root.Util
+{
+    /*
+     * BaseMonoBehaviour 클래스 개요
+     * - Unity에서 MonoBehaviour 객체는 C++ 객체(gameObject)와 C# 객체(MonoBehaviour)로 나뉘어 관리되며,
+     *   C# 객체는 가비지 컬렉션(GC)에 의해 수명이 관리된다.
+     * - MonoBehaviour 객체가 파괴되더라도 해당 객체가 참조하고 있는 모든 레퍼런스가 해제되지 않으면
+     *   GC가 이를 제거하지 못하고 메모리 상에 남아 있게 된다. 이를 "Ghost Reference" 문제라고 한다.
+     * - 이러한 문제는 레퍼런스 그래프의 비대화와 게임 퍼포먼스 저하(틱 불안정)를 초래할 수 있다.
+     * - 이를 해결하기 위해 OnDestroy에서 모든 멤버 변수의 참조를 명시적으로 null로 설정하거나 컬렉션을 비우는 작업을 수행해야 한다.
+     *
+     * [어떻게 동작하는지]
+     * - `OnDestroy` 메서드는 Reflection을 활용하여 현재 클래스의 모든 필드를 순회하며, 메모리 관리를 최적화하기 위해 다음 작업을 수행한다.
+     *   1. 모든 필드를 가져와(`FieldInfo`) 필드 타입을 확인한다.
+     *   2. 값 타입(`Primitive Type`)은 GC 대상이 아니므로 별도 처리 없이 건너뛴다.
+     *   3. 컬렉션 타입(`IList`, `IDictionary`, `Queue`, `Stack`, `HashSet`)인 경우, `Clear()` 메서드를 호출하여 내부 데이터를 제거한다.
+     *   4. 그 외의 참조 타입(클래스 객체 등)은 `null`을 할당하여 GC가 해당 객체를 해제할 수 있도록 한다.
+     */
+    public abstract class BaseMonoBehaviour : MonoBehaviour
+    {
+        [SuppressMessage("Reflection", "S3011", Justification = 
+            "필드의 메모리 해제를 자동화하기 위해 BindingFlags.NonPublic을 사용해야 함. " +
+            "MonoBehaviour의 필드들은 private, protected, internal인 경우가 많아, " +
+            "이를 포함하지 않으면 GC 해제가 완전하지 않을 수 있음.")]
+        protected virtual void OnDestroy()
+        {
+            // 현재 클래스의 모든 필드 가져오기
+            FieldInfo[] fields = GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            foreach (FieldInfo field in fields)
+            {
+                // 값 타입(Primitive Type)은 처리할 필요 없음 → continue
+                if (field.FieldType.IsValueType) continue;
+                
+                var fieldValue = field.GetValue(this);
+                switch (fieldValue)
+                {
+                    case null:
+                        continue;
+                    
+                    case IList list:
+                        list.Clear();
+                        break;
+                    
+                    case IDictionary dictionary:
+                        dictionary.Clear();
+                        break;
+                    
+                    case Queue queue:
+                        queue.Clear();
+                        break;
+                    
+                    case Stack stack:
+                        stack.Clear();
+                        break;
+                    
+                    case HashSet<object> hashSet:
+                        hashSet.Clear();
+                        break;
+                }
+
+                // 참조 해제하여 GC가 즉시 정리할 수 있도록 함
+                field.SetValue(this, null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- MonoBehaviourBase를 구현하였습니다
- 이제 모든 MonoBehaviour 객체는 MonoBehaviourBase 클래스를 상속받아야 합니다

# 제안 사항
- MonoBehaviourBase를 구현하였습니다
> Unity에서 MonoBehaviour 객체는 C++ 객체(gameObject)와 C# 객체(MonoBehaviour)로 나뉘어 관리되며,
> C# 객체는 가비지 컬렉션(GC)에 의해 수명이 관리된다.
> MonoBehaviour 객체가 파괴되더라도 해당 객체가 참조하고 있는 모든 레퍼런스가 해제되지 않으면
> GC가 이를 제거하지 못하고 메모리 상에 남아 있게 된다. 이를 "Ghost Reference" 문제라고 한다.
> 이러한 문제는 레퍼런스 그래프의 비대화와 게임 퍼포먼스 저하(틱 불안정)를 초래할 수 있다.
> 이를 해결하기 위해 OnDestroy에서 모든 멤버 변수의 참조를 명시적으로 null로 설정하거나 컬렉션을 비우는 작업을 수행해야 한다.


---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
