### PR TITLE
[Bug] TowerCreateHandler에서 제대로 배치 대기중인 타워의 Position이 핸들링되지 않는 현상 픽스

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/System/InGameManager.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/System/InGameManager.cs
@@ -18,6 +18,7 @@ namespace InGame.System
     {
         [SerializeField] protected DataManager dataManager;
         [SerializeField] protected CameraManager cameraManager;
+        public CameraManager CameraManager => cameraManager;
         
         protected override void Awake()
         {


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?


# 변경된 기능
- 마우스 포지션 데이터를 월드 포지션으로 변경하는 로직이 변경되었습니다
- 이제 정상적으로 데이터 변환이 이루어져, 마우스를 배치 대기중인 타워가 따라다닙니다


# 제안 사항
- 문제 원인
> ScreenToWorldPoint에서 Z_COORD = 0을 사용하여 변환된 좌표가 항상 같은 깊이에 고정됨.
> 이로 인해 마우스를 움직여도 타워가 미세하게만 움직이거나, 움직이지 않는 것처럼 보이는 문제 발생.
> 스크린 좌표 변환 시, 적절한 깊이값이 설정되지 않아 올바른 월드 좌표를 얻을 수 없음.
- 해결
> ScreenToWorldPoint의 Z 값으로 zDepth = -(mainCam.transform.position.z)를 설정.
> 카메라 위치를 기준으로 한 깊이를 사용하여 변환된 월드 좌표가 마우스 커서의 움직임을 제대로 반영하도록 수정.
> 결과적으로, 타워가 자연스럽게 마우스를 따라 움직이는 배치 시스템 완성.


# (선택)스크린샷


https://github.com/user-attachments/assets/5ac700d9-3c70-4ff6-bcb8-02d241a2dd7f


---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
