### PR TITLE
[Feat] Current Wave Count의 View와 Presenter 셋업

### DIFF
--- a/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
+++ b/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
@@ -44690,7 +44690,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1169179082}
   m_CullTransparentMesh: 1
---- !u!1 &1285339969
+--- !u!1 &1187875728
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -44698,42 +44698,42 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1285339970}
-  - component: {fileID: 1285339972}
-  - component: {fileID: 1285339971}
+  - component: {fileID: 1187875729}
+  - component: {fileID: 1187875731}
+  - component: {fileID: 1187875730}
   m_Layer: 5
-  m_Name: VW_Current Wave Count
+  m_Name: Text (TMP)_Current Wave Count
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1285339970
+--- !u!224 &1187875729
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1285339969}
+  m_GameObject: {fileID: 1187875728}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1849693001}
+  m_Father: {fileID: 1285339970}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 87.5}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1285339971
+--- !u!114 &1187875730
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1285339969}
+  m_GameObject: {fileID: 1187875728}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
@@ -44816,6 +44816,52 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1187875731
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1187875728}
+  m_CullTransparentMesh: 1
+--- !u!1 &1285339969
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1285339970}
+  - component: {fileID: 1285339972}
+  - component: {fileID: 1285339973}
+  m_Layer: 5
+  m_Name: VW_Current Wave Count
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1285339970
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285339969}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1187875729}
+  m_Father: {fileID: 1849693001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 87.5}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1285339972
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -44824,6 +44870,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1285339969}
   m_CullTransparentMesh: 1
+--- !u!114 &1285339973
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285339969}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91fe7067b179b434e8b670d4924b55fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  textWaveCount: {fileID: 1187875730}
 --- !u!1 &1304679034
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
+++ b/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
@@ -172,6 +172,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c1a2d26b613184979be52623d69e9996, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _vwCurrentWaveCount: {fileID: 1285339973}
 --- !u!1 &60519375
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_CurrentWaveCount.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_CurrentWaveCount.cs
@@ -1,4 +1,4 @@
-using Root.UI;
+using InGame.System;
 
 namespace InGame.Cases.TowerDefense.UI
 {
@@ -7,7 +7,7 @@ namespace InGame.Cases.TowerDefense.UI
     /// </summary>
     public sealed class PR_CurrentWaveCount : Presenter
     {
-        public override void Init(View view)
+        public override void Init(DataManager dataManager, View view)
         {
         }
     }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_CurrentWaveCount.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_CurrentWaveCount.cs
@@ -1,0 +1,14 @@
+using Root.UI;
+
+namespace InGame.Cases.TowerDefense.UI
+{
+    /// <summary>
+    /// Current Wave Count UI의 Presenter입니다.
+    /// </summary>
+    public sealed class PR_CurrentWaveCount : Presenter
+    {
+        public override void Init(View view)
+        {
+        }
+    }
+}

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VC_EnemyStatsPanel.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VC_EnemyStatsPanel.cs
@@ -1,4 +1,6 @@
 using InGame.System;
+using Root.Util;
+using UnityEngine;
 
 namespace InGame.Cases.TowerDefense.UI
 {
@@ -7,6 +9,14 @@ namespace InGame.Cases.TowerDefense.UI
     /// </summary>
     public sealed class VC_EnemyStatsPanel : ViewController
     {
+        [SerializeField] private VW_CurrentWaveCount _vwCurrentWaveCount;
+        private readonly PR_CurrentWaveCount _prCurrentWaveCount = new PR_CurrentWaveCount();
+
+        protected override void ValidateReferences()
+        {
+            AssertHelper.NotNull(typeof(VC_EnemyStatsPanel), _vwCurrentWaveCount);
+        }
+
         protected override void InitRef()
         {
         }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VC_EnemyStatsPanel.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VC_EnemyStatsPanel.cs
@@ -17,11 +17,7 @@ namespace InGame.Cases.TowerDefense.UI
             AssertHelper.NotNull(typeof(VC_EnemyStatsPanel), _vwCurrentWaveCount);
         }
 
-        protected override void InitRef()
-        {
-        }
-
-        public override void InitRx(DataManager dataManager)
+        public override void Init(DataManager dataManager)
         {
         }
 

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_CurrentWaveCount.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_CurrentWaveCount.cs
@@ -1,4 +1,4 @@
-using Root.UI;
+using InGame.System;
 using Root.Util;
 using TMPro;
 using UnityEngine;

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_CurrentWaveCount.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_CurrentWaveCount.cs
@@ -1,0 +1,11 @@
+using Root.UI;
+
+namespace InGame.Cases.TowerDefense.UI
+{
+    /// <summary>
+    /// Current Wave Count UI의 View입니다.
+    /// </summary>
+    public sealed class VW_CurrentWaveCount : View
+    {
+    }
+}

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_CurrentWaveCount.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_CurrentWaveCount.cs
@@ -1,4 +1,7 @@
 using Root.UI;
+using Root.Util;
+using TMPro;
+using UnityEngine;
 
 namespace InGame.Cases.TowerDefense.UI
 {
@@ -7,5 +10,11 @@ namespace InGame.Cases.TowerDefense.UI
     /// </summary>
     public sealed class VW_CurrentWaveCount : View
     {
+        [SerializeField] private TextMeshProUGUI textWaveCount;
+        
+        private void Awake()
+        {
+            AssertHelper.NotNull(typeof(VW_CurrentWaveCount), textWaveCount);
+        }
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/InGameAssembly.asmdef
+++ b/unity-skill-lab/Assets/Scripts/InGame/InGameAssembly.asmdef
@@ -6,7 +6,8 @@
         "GUID:a1d2aafb63704447b379c9daae015645",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:560b04d1a97f54a4e82edc0cbbb69285",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:6055be8ebefd69e48b49212b09b47b2f"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-skill-lab/Assets/Scripts/InGame/System/Presenter.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/System/Presenter.cs
@@ -1,7 +1,7 @@
 using System;
 using UniRx;
 
-namespace Root.UI
+namespace InGame.System
 {
     /// <summary>
     /// 프로젝트의 MVP UI 구조에서 사용되는 Presenter 추상 클래스입니다.
@@ -20,7 +20,7 @@ namespace Root.UI
         /// 해당 Presenter가 관리할 View를 전달받아 초기 설정을 진행합니다.
         /// </summary>
         /// <param name="view">초기화할 View 객체</param>
-        public abstract void Init(View view);
+        public abstract void Init(DataManager dataManager, View view);
        
         /// <summary>
         /// CompositeDisposable의 리소스를 정리하여 메모리 누수를 방지하는 Dispose 메서드입니다.

--- a/unity-skill-lab/Assets/Scripts/InGame/System/UIBindManager.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/System/UIBindManager.cs
@@ -18,7 +18,7 @@ namespace InGame.System
         {
             foreach (var elem in _viewControllers)
             {
-                elem.InitRx(dataManager);
+                elem.Init(dataManager);
             }
         }
         

--- a/unity-skill-lab/Assets/Scripts/InGame/System/View.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/System/View.cs
@@ -1,6 +1,6 @@
 using Root.Util;
 
-namespace Root.UI
+namespace InGame.System
 {
     /// <summary>
     /// 프로젝트의 MVP UI 구조에서 사용되는 View 클래스 입니다. 

--- a/unity-skill-lab/Assets/Scripts/InGame/System/ViewController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/System/ViewController.cs
@@ -14,7 +14,6 @@ namespace InGame.System
         private void Awake()
         {
             ValidateReferences();
-            InitRef();
             RegisterToUIManager();
         }
         
@@ -22,12 +21,6 @@ namespace InGame.System
         /// 필수 참조가 정상적으로 설정되었는지 검증합니다.
         /// </summary>
         protected abstract void ValidateReferences();
-
-        /// <summary>
-        /// View의 참조를 Presenter에게 전달하는 역할을 수행합니다.
-        /// View와 Presenter 간의 초기 연결을 담당합니다.
-        /// </summary>
-        protected abstract void InitRef();
 
         /// <summary>
         /// UIManager에 ViewController를 등록하는 역할을 수행합니다.
@@ -42,7 +35,7 @@ namespace InGame.System
         /// DataManager의 참조를 받아와 필요한 모델의 참조를 통해 Presenter의 초기화를 수행합니다.
         /// Presenter가 데이터에 접근할 수 있도록 설정하는 역할을 합니다.
         /// </summary>
-        public abstract void InitRx(DataManager dataManager);
+        public abstract void Init(DataManager dataManager);
         
         /// <summary>
         /// 프레젠터와 뷰의 자원을 정리할 때 사용합니다.

--- a/unity-skill-lab/Assets/Scripts/InGame/System/ViewController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/System/ViewController.cs
@@ -13,9 +13,15 @@ namespace InGame.System
     {
         private void Awake()
         {
+            ValidateReferences();
             InitRef();
             RegisterToUIManager();
         }
+        
+        /// <summary>
+        /// 필수 참조가 정상적으로 설정되었는지 검증합니다.
+        /// </summary>
+        protected abstract void ValidateReferences();
 
         /// <summary>
         /// View의 참조를 Presenter에게 전달하는 역할을 수행합니다.


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- VW_CurrentWaveCount, PR_CurrentWaveCount가 추가되었습니다
- ViewController의 추상 메서드 중 InitRef가 사라지고 InitRx가 Init으로 변경되었습니다


# 제안 사항
- Presenter 내부 메서드 조정
> InitRx를 Init으로 메서드 이름 변경하였습니다
> 메서드 이름을 바꾸어 추상화 수준을 올려, 올바르게 Init을 진행하면 바로 사용 가능한 상태로 만드는 것을 의도하였습니다
- VC_EnemyStatsPanel에서 InitRef 메서드 삭제
> 참조의 경우 Presenter가 Init될 때 함께 전달됩니다
> 따라서 별도의 메서드를 호출하지 않고, 초기화 될 때 한번에 모든 동작을 수행하게 의도하였습니다



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
