### PR TITLE
[Feat] 남은 적 수를 UI에 표시하는 기능 추가

### DIFF
--- a/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
+++ b/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
@@ -44243,7 +44243,7 @@ GameObject:
   - component: {fileID: 922502243}
   - component: {fileID: 922502242}
   m_Layer: 5
-  m_Name: Text (TMP)_Enemy Count Display
+  m_Name: Text (TMP)_Current Alive Enemy Count
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -49797,7 +49797,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 74650741c26124783990b7e7011142dc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  enemyCount: {fileID: 922502242}
+  currentAliveEnemyCount: {fileID: 922502242}
 --- !u!1 &1608653111
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Model/MDL_Enemy.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Model/MDL_Enemy.cs
@@ -12,5 +12,10 @@ namespace InGame.Cases.TowerDefense.System.Model
         private readonly Subject<EEnemyType> _onEnemySpawn = new Subject<EEnemyType>();
         public IObservable<EEnemyType> OnEnemySpawn => _onEnemySpawn;
         public void SpawnEnemy(EEnemyType type) => _onEnemySpawn.OnNext(type);
+        
+        // 적 유닛 사망과 관련된 Rx
+        private readonly Subject<EEnemyType> _onEnemyDeath = new Subject<EEnemyType>();
+        public IObservable<EEnemyType> OnEnemyDeath => _onEnemyDeath;
+        public void KillEnemy(EEnemyType type) => _onEnemyDeath.OnNext(type);
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_EnemyCountDisplay.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_EnemyCountDisplay.cs
@@ -7,6 +7,8 @@ namespace InGame.Cases.TowerDefense.UI
     /// </summary>
     public sealed class PR_EnemyCountDisplay : Presenter
     {
+        private uint _aliveEnemyCount;
+        
         public override void Init(DataManager dataManager, View view)
         {
         }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_EnemyCountDisplay.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_EnemyCountDisplay.cs
@@ -1,4 +1,7 @@
+using InGame.Cases.TowerDefense.System.Managers;
+using InGame.Cases.TowerDefense.System.Model;
 using InGame.System;
+using UniRx;
 
 namespace InGame.Cases.TowerDefense.UI
 {
@@ -7,10 +10,34 @@ namespace InGame.Cases.TowerDefense.UI
     /// </summary>
     public sealed class PR_EnemyCountDisplay : Presenter
     {
+        private VW_EnemyCountDisplay _vwEnemyCountDisplay;
         private uint _aliveEnemyCount;
-        
+
         public override void Init(DataManager dataManager, View view)
         {
+            _vwEnemyCountDisplay = view as VW_EnemyCountDisplay;
+            TowerDefenseDataManager tdDataManager = dataManager as TowerDefenseDataManager;
+            MDL_Enemy enemy = tdDataManager!.Enemy;
+
+            enemy.OnEnemySpawn
+                .Subscribe(_ => AddAliveEnemy())
+                .AddTo(disposable);
+            
+            enemy.OnEnemyDeath
+                .Subscribe(_ => RemoveAliveEnemy())
+                .AddTo(disposable);
+        }
+
+        private void AddAliveEnemy()
+        {
+            ++_aliveEnemyCount;
+            _vwEnemyCountDisplay.SetAliveEnemyCount(_aliveEnemyCount);
+        }
+
+        private void RemoveAliveEnemy()
+        {
+            --_aliveEnemyCount;
+            _vwEnemyCountDisplay.SetAliveEnemyCount(_aliveEnemyCount);
         }
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_EnemyCountDisplay.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_EnemyCountDisplay.cs
@@ -10,11 +10,13 @@ namespace InGame.Cases.TowerDefense.UI
     /// </summary>
     public sealed class VW_EnemyCountDisplay : View
     {
-        [SerializeField] private TextMeshProUGUI enemyCount;
+        [SerializeField] private TextMeshProUGUI currentAliveEnemyCount;
 
         private void Awake()
         {
-            AssertHelper.NotNull(typeof(VW_EnemyCountDisplay), enemyCount);
+            AssertHelper.NotNull(typeof(VW_EnemyCountDisplay), currentAliveEnemyCount);
         }
+        
+        public void SetAliveEnemyCount(uint aliveEnemyCount) => currentAliveEnemyCount.SetText(aliveEnemyCount.ToString());
     }
 }


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 이제 적 스폰 / 사망 이벤트와 Current Alive Enemy Count가 연동되어 UI를 표시합니다


# 제안 사항
- MDL_Enemy에 적 유닛의 사망과 관련된 Rx가 추가되었습니다
> Enemy는 자신이 죽을 때 이벤트를 알릴 곳이 필요하고, UI는 그 이벤트를 구독할 곳이 필요하여 모델에 Rx를 추가하게 되었습니다
- PR_EnemyCountDisplay에 _aliveEnemyCount 멤버 변수가 추가되었습니다
> 현재 저 데이터를 다룰 곳이 해당 프레젠터 외에는 없기 때문에 멤버 변수로 추가되었습니다
> 추후 여러 곳에서 사용될 경우 모델로 옮겨갈 가능성이 있습니다



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
