### PR TITLE
[Feat] 에너미가 생성될 때 EnemyBasePool에서 참조 전달하는 코드 추가

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/EnemyRoot.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/EnemyRoot.cs
@@ -1,3 +1,4 @@
+using InGame.Cases.TowerDefense.Enemy.Pool;
 using Root.Util;
 using UnityEngine;
 
@@ -14,11 +15,19 @@ namespace InGame.Cases.TowerDefense.Enemy
         
         [SerializeField] private EnemyStatController statController;
         public EnemyStatController StatController => statController;
+        
+        private EnemyDependencyContainer _dependencyContainer;
+        public EnemyDependencyContainer DependencyContainer => _dependencyContainer;
 
         private void Awake()
         {
             AssertHelper.NotNull(typeof(EnemyRoot), btBase);
             AssertHelper.NotNull(typeof(EnemyRoot), statController);
+        }
+
+        public void Init(EnemyDependencyContainer dependencyContainer)
+        {
+            _dependencyContainer = dependencyContainer;
         }
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/Pool/EnemyBasePool.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/Pool/EnemyBasePool.cs
@@ -14,5 +14,13 @@ namespace InGame.Cases.TowerDefense.Enemy.Pool
         {
             _dependencyContainer = new EnemyDependencyContainer(this, rootManager.DataManager.Enemy);
         }
+
+        protected override EnemyRoot CreatePooledItem()
+        {
+            var enemy = base.CreatePooledItem();
+            enemy.Init(_dependencyContainer);
+
+            return enemy;
+        }
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/Pool/EnemyBasePool.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/Pool/EnemyBasePool.cs
@@ -1,3 +1,4 @@
+using InGame.Cases.TowerDefense.System.Managers;
 using Root.Util;
 
 namespace InGame.Cases.TowerDefense.Enemy.Pool
@@ -7,5 +8,11 @@ namespace InGame.Cases.TowerDefense.Enemy.Pool
     /// </summary>
     public sealed class EnemyBasePool : ObjectPoolBase<EnemyRoot>
     {
+        private EnemyDependencyContainer _dependencyContainer;
+        
+        public void Init(TowerDefenseManager rootManager)
+        {
+            _dependencyContainer = new EnemyDependencyContainer(this, rootManager.DataManager.Enemy);
+        }
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/Pool/EnemyDependencyContainer.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/Pool/EnemyDependencyContainer.cs
@@ -1,0 +1,22 @@
+using InGame.Cases.TowerDefense.System.Model;
+
+namespace InGame.Cases.TowerDefense.Enemy.Pool
+{
+    /// <summary>
+    /// Enemy에서 사용될 외부 모듈의 참조를 관리하는 컨테이너 클래스입니다.
+    /// </summary>
+    public class EnemyDependencyContainer
+    {
+        private readonly EnemyBasePool _enemyBasePool;
+        public EnemyBasePool EnemyBasePool => _enemyBasePool;
+        
+        private readonly MDL_Enemy _mdlEnemy;
+        public MDL_Enemy MDLEnemy => _mdlEnemy;
+
+        public EnemyDependencyContainer(EnemyBasePool enemyBasePool, MDL_Enemy mdlEnemy)
+        {
+            _enemyBasePool = enemyBasePool;
+            _mdlEnemy = mdlEnemy;
+        }
+    }
+}

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Managers/TowerDefenseManager.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Managers/TowerDefenseManager.cs
@@ -39,8 +39,11 @@ namespace InGame.Cases.TowerDefense.System.Managers
 
         protected override void Init()
         {
+            base.Init();
+            
             _inputHandler = new TowerDefenseInputEventHandler();
             _createHandler = new TowerCreateHandler(this);
+            poolManager.Init(this);
             
             _towerDefenseSequenceManager.Init(this);
             spawnManager.Init(this);

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Managers/TowerDefensePoolManager.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Managers/TowerDefensePoolManager.cs
@@ -25,5 +25,10 @@ namespace InGame.Cases.TowerDefense.System.Managers
             AssertHelper.NotNull(typeof(TowerDefensePoolManager), towerProjectileBasePool);
             AssertHelper.NotNull(typeof(TowerDefensePoolManager), enemyBasePool);
         }
+
+        public void Init(TowerDefenseManager rootManager)
+        {
+            enemyBasePool.Init(rootManager);
+        }
     }
 }


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- EnemyDependencyContainer가 구현되었습니다
- EnemyBasePool 에서 초기화 됩니다
- EnemyRoot에서 이 참조를 사용할 수 있습니다


# 제안 사항
- EnemyDependencyContainer가 구현되었습니다
> 해당 클래스의 역할은 에너미에서 사용될 외부 모듈의 참조를 지니고 있습니다
> `EnemyBasePool`과 `MDL_Enemy`의 참조를 가지고 있습니다
- EnemyBasePool 에서 초기화 됩니다
> 단순 참조만을 가지고 있기 때문에 하나의 인스턴스로 돌려쓰면 됩니다
> 따라서 EnemyBasePool에서 Init을 진행하고, 아이템을 생성할 때 전달해 줍니다



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
