### PR TITLE
[Refactor] TowerAttackController 내부 StartAttacking에서 쿨다운을 관리하는 로직 수정

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Tower/TowerAttackController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Tower/TowerAttackController.cs
@@ -177,19 +177,20 @@ namespace InGame.Cases.TowerDefense.Tower
             {
                 // FixedUpdate 타이밍에서 실행되도록 대기
                 await UniTask.NextFrame(PlayerLoopTiming.FixedUpdate, token); 
+                
+                // 쿨다운이 남아 있으면 감소시키기
+                if (_fireCooldown > 0)
+                {
+                    _fireCooldown = Mathf.Max(_fireCooldown - Time.fixedDeltaTime, 0f);
+                }
 
                 // 현재 타겟이 없다면 다음 루프로 이동
                 if (_currentTarget == null)
                 {
                     continue;
                 }
-
-                // 쿨다운이 남아 있으면 감소시키고 다음 루프로 이동
-                if (_fireCooldown > 0)
-                {
-                    _fireCooldown = Mathf.Max(_fireCooldown - Time.fixedDeltaTime, 0f);
-                    continue;
-                }
+                
+                // TODO: 타겟의 상태를 체크. 죽었다면 클리어 타겟 수행
 
                 Vector3 targetDir = (_currentTarget.transform.position - firePoint.position).normalized;
                 SetMuzzleRotation(targetDir);


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 이제 타워가 공격 쿨타임이 남아있을 경우 무조건 공격 쿨타임부터 줄어들도록 분기를 조정하였습니다


# 제안 사항
- TowerAttackController.StartAttacking 함수 내부 실행 순서 조정
> 쿨타임 관련 if문의 호출이 먼저 일어나도록 올리고 continue를 제거하였습니다
> 쿨타임이 다른 코드에 영향을 주어선 안되기 때문입니다



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
