### PR TITLE
[Refactor] TowerAttackController의 IDisposable 상속 해제

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Tower/TowerAttackController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Tower/TowerAttackController.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using CleverCrow.Fluid.BTs.Tasks;
 using Cysharp.Threading.Tasks;
@@ -14,7 +13,7 @@ namespace InGame.Cases.TowerDefense.Tower
     /// <summary>
     /// 타워의 공격을 관리하는 컨트롤러 클래스입니다.
     /// </summary>
-    public sealed class TowerAttackController : MonoBehaviourBase, IDisposable
+    public sealed class TowerAttackController : MonoBehaviourBase
     {
         /// <summary>
         /// 타워가 감지할 대상의 레이어 마스크입니다.
@@ -303,8 +302,10 @@ namespace InGame.Cases.TowerDefense.Tower
             return Mathf.Abs(angleToTarget) <= angleThreshold;
         }
         
-        public void Dispose()
+        protected override void OnDestroy()
         {
+            base.OnDestroy();
+            
             CancelTokenHelper.ClearToken(in _cts);
         }
     }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Tower/TowerRoot.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Tower/TowerRoot.cs
@@ -34,12 +34,5 @@ namespace InGame.Cases.TowerDefense.Tower
             _btController = new TowerBTController(gameObject, attackController);
             attackController.Init();
         }
-
-        protected override void OnDestroy()
-        {
-            base.OnDestroy();
-            
-            attackController.Dispose();
-        }
     }
 }


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- TowerAttackController에서 IDisposable 상속 제거
- TowerAttackController가 스스로 OnDestroy에서 자원 정리 수행
- TowerRoot에서 TowerAttackController의 수명 관리 및 명시적 Dispose 호출 제거
- 타워 객체 수명 관리 구조 간소화 및 명확화


# 제안 사항
- TowerAttackController의 IDisposable 상속 제거
> MonoBehaviourBase를 상속받고 있어, Unity 수명주기에서 OnDestroy를 활용할 수 있음
> Unity 환경에서는 IDisposable 패턴보다 OnDestroy가 더 자연스럽고 관리가 쉬움
> 외부에서 명시적으로 Dispose를 호출하지 않아도, 오브젝트 파괴 시 자동 정리되도록 개선

- TowerRoot에서 OnDestroy에서 수행하던 Dispose 호출 제거
> TowerAttackController가 스스로 정리 책임을 가지므로, 상위 객체에서 관리할 필요가 사라짐
> 상위 객체에서 하위 컴포넌트의 수명 및 정리 로직에 개입하지 않아, 컴포넌트 간 결합도 감소


---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
