### PR TITLE
[Bug] TowerAttackController에서 발생하는 NullReferenceException 에러 픽스

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Tower/TowerAttackController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Tower/TowerAttackController.cs
@@ -304,9 +304,9 @@ namespace InGame.Cases.TowerDefense.Tower
         
         protected override void OnDestroy()
         {
-            base.OnDestroy();
-            
             CancelTokenHelper.ClearToken(in _cts);
+            
+            base.OnDestroy();
         }
     }
 }


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- OnDestroy 시점에서 멤버 참조 해제 타이밍 조정


# 제안 사항
- OnDestroy에서 멤버 해제 순서 조정
> 기존에는 base.OnDestroy()를 먼저 호출해 MonoBehaviourBase의 멤버 해제 후, 자식 클래스의 정리 로직이 수행되었음. 
> 이 경우, 비동기 루틴(UniTask)이 한 사이클 더 돌면서 이미 해제된 멤버에 접근하는 문제가 발생했음. 
> 이를 방지하기 위해 base.OnDestroy() 호출을 맨 마지막으로 이동하여, 모든 정리 작업 후 최종적으로 부모 클래스의 해제가 이뤄지도록 수정.


# (선택)스크린샷

https://github.com/user-attachments/assets/6b055ba1-5685-4dc2-9bc5-84b0e6a3e293



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
