### PR TITLE
[Bug] VC_EnemyStatsPanel에서 발생하는 NullReferenceException 에러 픽스

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VC_EnemyStatsPanel.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VC_EnemyStatsPanel.cs
@@ -26,7 +26,7 @@ namespace InGame.Cases.TowerDefense.UI
             _prCurrentWaveCount.Init(dataManager, _vwCurrentWaveCount);
         }
 
-        public override void Dispose()
+        protected override void ReleasePresenter()
         {
             _prCurrentWaveCount.Dispose();
         }

--- a/unity-skill-lab/Assets/Scripts/InGame/System/InGameManager.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/System/InGameManager.cs
@@ -52,12 +52,5 @@ namespace InGame.System
 
         protected abstract void SetDataManager();
         protected abstract void SetSequenceManager();
-
-        protected override void OnDispose()
-        {
-            base.OnDispose();
-            
-            _uiBindManager.Dispose();
-        }
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/System/UIBindManager.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/System/UIBindManager.cs
@@ -1,13 +1,12 @@
-using System;
 using System.Collections.Generic;
 
 namespace InGame.System
 {
     /// <summary>
     /// 씬에서 사용되는 모델 - 프레젠터 - 뷰의 바인딩을 수행하는 클래스입니다.
-    /// ViewController를 등록하고, 초기화하며, 필요 시 해제하는 역할을 합니다.
+    /// ViewController를 등록하고, 초기화합니다.
     /// </summary>
-    public class UIBindManager : IDisposable
+    public class UIBindManager
     {
         private readonly List<ViewController> _viewControllers = new List<ViewController>();
         
@@ -28,17 +27,6 @@ namespace InGame.System
         public void AddViewController(ViewController viewController)
         {
             _viewControllers.Add(viewController);
-        }
-        
-        /// <summary>
-        /// 모든 ViewController의 Dispose를 호출하여 등록된 ViewController들을 정리합니다.
-        /// </summary>
-        public void Dispose()
-        {
-            foreach (var elem in _viewControllers)
-            {
-                elem.Dispose();
-            }
         }
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/System/ViewController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/System/ViewController.cs
@@ -1,4 +1,3 @@
-using System;
 using Root.Util;
 using UnityEngine;
 
@@ -10,7 +9,7 @@ namespace InGame.System
     /// 두 모듈의 참조를 가지고 초기화만 수행합니다. 비즈니스 로직은 절대 담당하지 않습니다.
     /// ViewController를 상속받는 모든 클래스는 접두사 VC가 붙습니다.
     /// </summary>
-    public abstract class ViewController : MonoBehaviourBase, IDisposable
+    public abstract class ViewController : MonoBehaviourBase
     {
         [SerializeField] private InGameManager _inGameManager;
         
@@ -43,9 +42,15 @@ namespace InGame.System
         public abstract void Init(DataManager dataManager);
         
         /// <summary>
-        /// 프레젠터와 뷰의 자원을 정리할 때 사용합니다.
-        /// TowerDefenseUIManager에서 Dispose를 호출됩니다.
+        /// 프레젠터의 자원을 정리할 때 사용합니다.
         /// </summary>
-        public abstract void Dispose();
+        protected abstract void ReleasePresenter();
+
+        protected override void OnDestroy()
+        {
+            ReleasePresenter();
+            
+            base.OnDestroy();
+        }
     }
 }


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 각 ViewController가 자신의 프레젠터 정리 책임을 갖도록 구조 변경
- InGameManager가 ViewController 정리 책임을 갖지 않음
- UIBindManager가 더 이상 IDisposable을 상속하지 않고, 수동 Dispose 제거


# 제안 사항
- UIBindManager의 IDisposable 상속 제거 및 Dispose 메서드 삭제
> 각 ViewController가 자신의 수명 주기를 관리하는 방식으로 변경하면서, UIBindManager 차원에서 일괄 정리할 필요성이 사라짐
> 따라서 UIBindManager는 ViewController를 등록/조회 역할만 남기고, 직접적인 해제 책임은 제거

- ViewController의 IDisposable 상속 해제 및 Dispose 메서드의 접근 한정자 protected로 변경
> ViewController는 자신의 라이프사이클 내에서 프레젠터 정리를 수행하도록 변경
> 상속받은 클래스들이 필요에 따라 override하도록 유도하고, 외부 호출은 차단해 일관성 유지
> Dispose라는 네이밍은 혼동 가능성이 있어, 역할이 명확한 ReleasePresenter로 메서드명 교체

- ViewController의 OnDestroy에서 base.OnDestroy 호출 위치 변경 및 ReleasePresenter 호출 추가
> OnDestroy에서 base.OnDestroy 호출 이후 참조 해제가 발생하는 문제로 인해, base.OnDestroy 호출 전에 ReleasePresenter를 호출하여 프레젠터 정리를 보장
> 이를 통해 참조 해제로 인한 NullReferenceException 방지


# (선택)스크린샷

https://github.com/user-attachments/assets/6d21f33e-6505-4193-8cc3-519d78e04248





---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
