### PR TITLE
[Feat] Wave가 시작될 때 Current Wave Count가 증가하는 기능 구현

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -14,11 +14,13 @@ namespace InGame.Cases.TowerDefense.System
     public class RoundController : IDisposable
     {
         private readonly MDL_Enemy _enemyModel;
+        private readonly MDL_Round _roundModel;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
         public RoundController(TowerDefenseDataManager dataManager)
         {
             _enemyModel = dataManager.Enemy;
+            _roundModel = dataManager.Round;
         }
 
         /// <summary>

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -49,6 +49,9 @@ namespace InGame.Cases.TowerDefense.System
         /// </summary>
         private async UniTask StartRound(CancellationToken token)
         {
+            const int ROUND_INCREMENT = 1;
+            _roundModel.SetCurrentRound(_roundModel.CurrentRound.Value + ROUND_INCREMENT);
+            
             for (int i = 0; i < 5; i++)
             {
                 if (token.IsCancellationRequested) return;


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 웨이브 시작 시 Current Wave Count UI가 1씩 증가하는 기능 추가


# 제안 사항
- RoundController.StartRound에서 웨이브 시작 시 라운드 카운트 증가 처리 추가
> 웨이브 진행 상태와 UI 표시값이 일치하지 않는 문제 해결을 위해, 웨이브 시작 시점에서 카운트를 갱신하도록 변경


# (선택)스크린샷

https://github.com/user-attachments/assets/9cdd9cab-28c9-4c60-a8c2-82fab6625165



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
