### PR TITLE
[Feat] ERoundStates에 Spawning 상태 추가, InProgress와의 상태 분리 진행

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Enums.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Enums.cs
@@ -64,6 +64,11 @@ namespace InGame.Cases.TowerDefense.System
         None,
 
         /// <summary>
+        /// 적 소환 중.
+        /// </summary>
+        Spawning,
+        
+        /// <summary>
         /// 라운드 진행 중.
         /// </summary>
         InProgress,

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -51,7 +51,7 @@ namespace InGame.Cases.TowerDefense.System
         {
             const int ROUND_INCREMENT = 1;
             _roundModel.SetCurrentRound(_roundModel.CurrentRound.Value + ROUND_INCREMENT);
-            _roundModel.SetRoundState(ERoundStates.InProgress);
+            _roundModel.SetRoundState(ERoundStates.Spawning);
             
             for (int i = 0; i < 5; i++)
             {
@@ -61,6 +61,8 @@ namespace InGame.Cases.TowerDefense.System
                 
                 await UniTask.Delay(TimeSpan.FromSeconds(1), cancellationToken: token);
             }
+            
+            _roundModel.SetRoundState(ERoundStates.InProgress);
         }
 
         /// <summary>


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?


# 변경된 기능
- 라운드 진행 상태 구분 강화를 위해 ERoundStates에 Spawning 상태 추가
- 기존 InProgress 상태를 적 스폰 완료 후 전투 진행 중 상태로 역할 변경


# 제안 사항
- ERoundStates에 Spawning 상태 추가
> 라운드 시작 직후 적이 순차적으로 소환되는 단계와, 모든 적이 소환 완료된 이후 실제 전투가 진행되는 단계를 분리해, 라운드 상태 흐름을 명확하게 정의

- RoundController.StartRound에서 라운드 시작 시 Spawning 상태로 전환
> 적 스폰 중이라는 명확한 상태 표시로, 불필요한 종료 판정이나 상태 오인 방지


---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
