### PR TITLE
[Feat] RoundController.IsRoundOver 메서드 구현

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -11,11 +11,13 @@ namespace InGame.Cases.TowerDefense.System
     /// 타워 디펜스 게임의 라운드를 관리하는 클래스.
     /// 라운드 진행 흐름을 제어하며, 웨이브 시작 및 종료 등의 동작을 수행한다.
     /// </summary>
-    public class RoundController : IDisposable
+    public sealed class RoundController : IDisposable
     {
         private readonly MDL_Enemy _enemyModel;
         private readonly MDL_Round _roundModel;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
+        private int _remainingEnemyCount;
 
         public RoundController(TowerDefenseDataManager dataManager)
         {

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -19,7 +19,7 @@ namespace InGame.Cases.TowerDefense.System
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         private readonly CompositeDisposable _disposable = new CompositeDisposable();
 
-        private int _remainingEnemyCount;
+        private uint _remainingEnemyCount;
 
         public RoundController(TowerDefenseDataManager dataManager)
         {
@@ -105,8 +105,14 @@ namespace InGame.Cases.TowerDefense.System
         /// </summary>
         private bool IsRoundOver()
         {
-            // TODO: 적이 모두 처치되거나 EndPoint까지 도달했는지 확인하는 로직 추가
-            return false;
+            // 라운드 진행 중 상태가 아닐 경우, 종료 조건을 체크하지 않음
+            if (_roundModel.RoundState.Value != ERoundStates.InProgress)
+            {
+                return false;
+            }
+
+            // 활성화된 적이 모두 사라졌을 경우, 라운드 종료
+            return _remainingEnemyCount == 0;
         }
 
         /// <summary>


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 라운드 종료 조건을 관리하는 IsRoundOver 메서드 구현
- 라운드 종료 조건으로 현재 상태가 InProgress인지 여부 및 현재 활성화된 적의 개수 확인 로직 추가
- MDL_Enemy의 OnEnemySpawn, OnEnemyDeath 이벤트 구독을 통해 적 수 증감 관리


# 제안 사항
- RoundController에 _remainingEnemyCount 멤버 변수 추가
> 현재 활성화된 적의 개수를 실시간으로 관리하고, 라운드 종료 조건 판단 시 활용

- RoundController 생성자에서 MDL_Enemy의 OnEnemySpawn, OnEnemyDeath 구독 처리
> 적 생성 시 카운트 증가, 적 사망 시 카운트 감소로 활성화된 적 수를 정확하게 추적

- IsRoundOver 메서드 구현
> 라운드 상태가 InProgress인지 확인 후, 활성화된 적 수가 0일 때 라운드 종료 조건을 만족하는 구조로 처리
> 라운드 상태별 종료 조건 오작동 방지 및 이후 보스 웨이브 등 추가 조건 확장 가능성 대비


---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
