### PR TITLE
[Refactor] 라운드 종료 대기 방식 변경 및 종료 조건 관리 구조 개선

### DIFF
--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/EnemyStatController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/Enemy/EnemyStatController.cs
@@ -66,7 +66,6 @@ namespace InGame.Cases.TowerDefense.Enemy
         public void TakeDamage(float damage)
         {
             _currentHP = Mathf.Max(0, _currentHP - damage);
-            Debug.Log($"Enemy took {damage} damage. Remaining HP: {_currentHP}");
             _hitEffectController.PlayHitFlash();
 
             if (_currentHP > 0) return;

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -93,12 +93,8 @@ namespace InGame.Cases.TowerDefense.System
         /// </summary>
         private async UniTask EndRound(CancellationToken token)
         {
-            while (!IsRoundOver())
-            {
-                if (token.IsCancellationRequested) return;
-                
-                await UniTask.Yield();
-            }
+            // 적 전멸 이벤트 대기
+            await _roundEndEvent.ToUniTask(cancellationToken: token);
         }
 
         /// <summary>

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -18,6 +18,7 @@ namespace InGame.Cases.TowerDefense.System
         private readonly MDL_Round _roundModel;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         private readonly CompositeDisposable _disposable = new CompositeDisposable();
+        private readonly Subject<Unit> _roundEndEvent = new Subject<Unit>();
 
         private uint _remainingEnemyCount;
 

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -32,7 +32,17 @@ namespace InGame.Cases.TowerDefense.System
                 .AddTo(_disposable);
             
             _enemyModel.OnEnemyDeath
-                .Subscribe(_ => --_remainingEnemyCount)
+                .Subscribe(_ =>
+                {
+                    --_remainingEnemyCount;
+                    
+                    // InProgress 상태가 아닐 경우, 종료 조건을 체크하지 않음
+                    if (_roundModel.RoundState.Value != ERoundStates.InProgress) return;
+                    // 활성화된 적이 남아있을 경우 종료 조건을 체크하지 않음
+                    if (_remainingEnemyCount > 0) return;
+                    
+                    _roundEndEvent.OnNext(Unit.Default);
+                })
                 .AddTo(_disposable);
         }
 

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -108,21 +108,6 @@ namespace InGame.Cases.TowerDefense.System
         }
 
         /// <summary>
-        /// 현재 라운드가 종료되었는지 확인한다.
-        /// </summary>
-        private bool IsRoundOver()
-        {
-            // 라운드 진행 중 상태가 아닐 경우, 종료 조건을 체크하지 않음
-            if (_roundModel.RoundState.Value != ERoundStates.InProgress)
-            {
-                return false;
-            }
-
-            // 활성화된 적이 모두 사라졌을 경우, 라운드 종료
-            return _remainingEnemyCount == 0;
-        }
-
-        /// <summary>
         /// 루프를 중단하고 리소스를 정리한다.
         /// </summary>
         public void Dispose()


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 라운드 종료 대기 방식 변경
- IsRoundOver 메서드 제거
- 적 전멸 감지 및 라운드 종료 트리거를 bool 플래그와 WaitUntil로 단순화


# 제안 사항
- 라운드 종료 대기 방식 변경
> bool 플래그와 WaitUntil을 활용해 라운드 종료 대기 흐름을 단순화

- 적 전멸 감지 로직 추가
> 적 사망 시점에서 _remainingEnemyCount와 라운드 상태를 함께 체크하고, 모든 조건 충족 시 _isRoundOver 플래그를 true로 설정하는 구조로 변경
> 라운드 종료 트리거 흐름을 직관적으로 관리할 수 있도록 개선했습니다.



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
