### PR TITLE
[Feat] Round Info UI에 현재 라운드 진행 상태와 다음 라운드 시작 시간까지에 대한 정보를 제공하는 기능 구현

### DIFF
--- a/unity-skill-lab/Assets/Plugins/UniRx/Scripts/Observer.cs
+++ b/unity-skill-lab/Assets/Plugins/UniRx/Scripts/Observer.cs
@@ -6,6 +6,12 @@ namespace UniRx
 {
     public static class Observer
     {
+        /// <summary>
+        /// Rx 구독 시 첫 번째 발행 값을 무시하도록 설정하는 기본 스킵 값입니다.
+        /// 최초 값은 유효하지 않은 경우가 많아, 이를 방지하기 위한 용도로 사용됩니다.
+        /// </summary>
+        public const int INITIAL_SUBSCRIPTION_SKIP_COUNT = 1;
+
         internal static IObserver<T> CreateSubscribeObserver<T>(Action<T> onNext, Action<Exception> onError, Action onCompleted)
         {
             // need compare for avoid iOS AOT

--- a/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
+++ b/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
@@ -44899,7 +44899,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Current Wave Count
+  m_text: Current Round Count
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
   m_sharedMaterial: {fileID: -6382555307566913213, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}

--- a/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
+++ b/unity-skill-lab/Assets/Scenes/Case_TowerDefense.unity
@@ -234,15 +234,15 @@ MonoBehaviour:
       m_Calls: []
   m_text: Main Panel
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
+  m_sharedMaterial: {fileID: -6382555307566913213, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -668,15 +668,15 @@ MonoBehaviour:
       m_Calls: []
   m_text: C
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
+  m_sharedMaterial: {fileID: -6382555307566913213, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -44306,15 +44306,15 @@ MonoBehaviour:
       m_Calls: []
   m_text: Enemy Count Display
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
+  m_sharedMaterial: {fileID: -6382555307566913213, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -44901,15 +44901,15 @@ MonoBehaviour:
       m_Calls: []
   m_text: Current Wave Count
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
+  m_sharedMaterial: {fileID: -6382555307566913213, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -45094,15 +45094,15 @@ MonoBehaviour:
       m_Calls: []
   m_text: Round Info
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
+  m_sharedMaterial: {fileID: -6382555307566913213, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -45317,15 +45317,15 @@ MonoBehaviour:
       m_Calls: []
   m_text: Difficulty Settings Panel
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
+  m_sharedMaterial: {fileID: -6382555307566913213, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -49605,15 +49605,15 @@ MonoBehaviour:
       m_Calls: []
   m_text: Resources
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
+  m_sharedMaterial: {fileID: -6382555307566913213, guid: 9e0c59745b73f4f5e871a1f7ce374b27, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Model/MDL_Round.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Model/MDL_Round.cs
@@ -16,5 +16,10 @@ namespace InGame.Cases.TowerDefense.System.Model
         private readonly ReactiveProperty<ERoundStates> _roundState = new ReactiveProperty<ERoundStates>(ERoundStates.None);
         public IReadOnlyReactiveProperty<ERoundStates> RoundState => _roundState;
         public void SetRoundState(ERoundStates state) => _roundState.Value = state;
+        
+        // 다음 라운드까지의 카운트다운을 나타내는 Rx
+        private readonly ReactiveProperty<uint> _nextRoundCountDown = new ReactiveProperty<uint>(0);
+        public IReadOnlyReactiveProperty<uint> NextRoundCountDown => _nextRoundCountDown;
+        public void SetNextRoundCountDown(uint countDown) => _nextRoundCountDown.Value = countDown;
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Model/MDL_Round.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/Model/MDL_Round.cs
@@ -13,7 +13,7 @@ namespace InGame.Cases.TowerDefense.System.Model
         public void SetCurrentRound(uint round) => _currentRound.Value = round;
         
         // 현재 라운드의 상태를 나타내는 Rx
-        private readonly ReactiveProperty<ERoundStates> _roundState = new ReactiveProperty<ERoundStates>(ERoundStates.None);
+        private readonly ReactiveProperty<ERoundStates> _roundState = new ReactiveProperty<ERoundStates>(ERoundStates.Spawning);
         public IReadOnlyReactiveProperty<ERoundStates> RoundState => _roundState;
         public void SetRoundState(ERoundStates state) => _roundState.Value = state;
         

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -109,7 +109,7 @@ namespace InGame.Cases.TowerDefense.System
 
             _roundModel.SetRoundState(ERoundStates.Waiting);
             
-            UniTask.Delay(TimeSpan.FromSeconds(INITIAL_DELAY_SECONDS), cancellationToken: token);
+            await UniTask.Delay(TimeSpan.FromSeconds(INITIAL_DELAY_SECONDS), cancellationToken: token);
 
             for (uint i = 0; i < NEXT_ROUND_WAIT_SECONDS; ++i)
             {

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -103,9 +103,18 @@ namespace InGame.Cases.TowerDefense.System
         /// </summary>
         private async UniTask WaitForNextRound(CancellationToken token)
         {
+            const uint NEXT_ROUND_WAIT_SECONDS = 10;
+            const uint COUNTDOWN_INTERVAL_SECONDS = 1;
+
+            _roundModel.SetNextRoundCountDown(NEXT_ROUND_WAIT_SECONDS);
             _roundModel.SetRoundState(ERoundStates.Waiting);
-   
-            await UniTask.Delay(TimeSpan.FromSeconds(10), cancellationToken: token);
+
+            for (uint i = 0; i < NEXT_ROUND_WAIT_SECONDS; ++i)
+            {
+                _roundModel.SetNextRoundCountDown(NEXT_ROUND_WAIT_SECONDS - i);
+
+                await UniTask.Delay(TimeSpan.FromSeconds(COUNTDOWN_INTERVAL_SECONDS), cancellationToken: token);
+            }
         }
 
         /// <summary>

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/System/RoundController.cs
@@ -105,9 +105,11 @@ namespace InGame.Cases.TowerDefense.System
         {
             const uint NEXT_ROUND_WAIT_SECONDS = 10;
             const uint COUNTDOWN_INTERVAL_SECONDS = 1;
+            const uint INITIAL_DELAY_SECONDS = 3;
 
-            _roundModel.SetNextRoundCountDown(NEXT_ROUND_WAIT_SECONDS);
             _roundModel.SetRoundState(ERoundStates.Waiting);
+            
+            UniTask.Delay(TimeSpan.FromSeconds(INITIAL_DELAY_SECONDS), cancellationToken: token);
 
             for (uint i = 0; i < NEXT_ROUND_WAIT_SECONDS; ++i)
             {

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_RoundInfo.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_RoundInfo.cs
@@ -23,6 +23,7 @@ namespace InGame.Cases.TowerDefense.UI
                 .AddTo(disposable);
             
             tdDataManager.Round.NextRoundCountDown
+                .Skip(Observer.INITIAL_SUBSCRIPTION_SKIP_COUNT)
                 .Subscribe(roundInfo.ApplyNextRoundCountDown)
                 .AddTo(disposable);
         }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_RoundInfo.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/PR_RoundInfo.cs
@@ -1,6 +1,7 @@
 using InGame.Cases.TowerDefense.System.Managers;
 using InGame.System;
 using Root.Util;
+using UniRx;
 
 namespace InGame.Cases.TowerDefense.UI
 {
@@ -14,8 +15,16 @@ namespace InGame.Cases.TowerDefense.UI
             TowerDefenseDataManager tdDataManager = dataManager as TowerDefenseDataManager;
             AssertHelper.NotNull(typeof(PR_RoundInfo), tdDataManager);
             
-            VW_RoundInfo currentRoundCount =  view as VW_RoundInfo;
-            AssertHelper.NotNull(typeof(PR_RoundInfo), currentRoundCount);
+            VW_RoundInfo roundInfo =  view as VW_RoundInfo;
+            AssertHelper.NotNull(typeof(PR_RoundInfo), roundInfo);
+            
+            tdDataManager!.Round.RoundState
+                .Subscribe(roundInfo!.ApplyRoundStates)
+                .AddTo(disposable);
+            
+            tdDataManager.Round.NextRoundCountDown
+                .Subscribe(roundInfo.ApplyNextRoundCountDown)
+                .AddTo(disposable);
         }
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_RoundInfo.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_RoundInfo.cs
@@ -37,5 +37,14 @@ namespace InGame.Cases.TowerDefense.UI
 
             roundInfo.SetText(RoundStateTexts[states]);
         }
+        
+        /// <summary>
+        /// 다음 라운드 시작까지 남은 시간을 UI에 표시합니다.
+        /// </summary>
+        /// <param name="countdown">다음 라운드 시작까지 남은 시간(초)</param>
+        public void ApplyNextRoundCountdown(uint countdown)
+        {
+            roundInfo.SetText("적 재정비중... : {0}", countdown);
+        }
     }
 }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_RoundInfo.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_RoundInfo.cs
@@ -42,7 +42,7 @@ namespace InGame.Cases.TowerDefense.UI
         /// 다음 라운드 시작까지 남은 시간을 UI에 표시합니다.
         /// </summary>
         /// <param name="countdown">다음 라운드 시작까지 남은 시간(초)</param>
-        public void ApplyNextRoundCountdown(uint countdown)
+        public void ApplyNextRoundCountDown(uint countdown)
         {
             roundInfo.SetText("적 재정비중... : {0}", countdown);
         }

--- a/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_RoundInfo.cs
+++ b/unity-skill-lab/Assets/Scripts/InGame/Cases/TowerDefense/UI/VW_RoundInfo.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using InGame.Cases.TowerDefense.System;
 using InGame.System;
 using Root.Util;
 using TMPro;
@@ -11,10 +13,29 @@ namespace InGame.Cases.TowerDefense.UI
     public sealed class VW_RoundInfo : View
     {
         [SerializeField] private TextMeshProUGUI roundInfo;
-        
+
+        private static readonly Dictionary<ERoundStates, string> RoundStateTexts = new()
+        {
+            { ERoundStates.Spawning, "적들이 몰려오고 있습니다!" },
+            { ERoundStates.InProgress, "방어선 유지 중!" },
+            { ERoundStates.Waiting, "적이 물러서고 있습니다!" }
+        };
+
         private void Awake()
         {
             AssertHelper.NotNull(typeof(VW_RoundInfo), roundInfo);
+        }
+
+        /// <summary>
+        /// 현재 라운드 상태에 해당하는 정보를 UI에 표시합니다.
+        /// 상태별로 지정된 문구를 출력하며, 상태 값은 반드시 유효한 값이어야 합니다.
+        /// </summary>
+        /// <param name="states">적용할 라운드 상태</param>
+        public void ApplyRoundStates(ERoundStates states)
+        {
+            Debug.Assert(states != ERoundStates.None, "states != ERoundStates.None");
+
+            roundInfo.SetText(RoundStateTexts[states]);
         }
     }
 }


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?


# 변경된 기능
- 라운드 진행 상태와 다음 라운드 시작까지의 남은 시간을 UI로 실시간 제공하는 기능이 추가되었습니다.
- 라운드의 상태 변화와 카운트다운 정보가 각각의 흐름으로 분리되었으며, UI는 이 두 흐름을 각각 구독해 동작합니다.
- Rx 구독 시 의도치 않은 초기값 발행을 방지하기 위해, 구독 시점에서 최초 이벤트를 무시하는 기본 컨벤션이 추가되었습니다.


# 제안 사항
- 라운드 진행 상태와 다음 라운드 대기 시간을 각각 독립적인 스트림으로 관리
> 라운드 상태 변화와 카운트다운 진행이 서로 다른 의미와 흐름을 갖기 때문에, 한 스트림에서 함께 처리하는 방식 대신 각각의 독립적인 흐름으로 관리하도록 분리하였습니다.
> 상태 변경은 이벤트성, 카운트다운은 지속적 흐름이라는 성격 차이를 명확히 구분해 관리 효율성을 높였습니다.

- 룩업 테이블 도입을 통한 상태별 텍스트 관리 일원화
> 라운드 상태별로 표시할 문구를 룩업 테이블로 관리해, 상태 추가 및 변경 시 Switch 문 수정 없이 테이블만 수정하도록 변경했습니다.
텍스트 변경이나 다국어 지원 시에도 관리가 수월해집니다.

- Rx 구독 시 최초 발행 값 무시를 공통 컨벤션으로 설정
> Rx의 특성상 구독 즉시 발행되는 초기 값은 유효하지 않을 가능성이 높아, 모든 구독 흐름에서 첫 이벤트를 스킵하는 컨벤션을 추가했습니다.
> 이를 Observer.INITIAL_SUBSCRIPTION_SKIP_COUNT로 상수화해, 일관된 방식으로 적용하고 명확한 의도를 드러냈습니다.



# (선택)스크린샷

https://github.com/user-attachments/assets/c561050a-ecc1-4640-8708-94844bd84992



---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
